### PR TITLE
code(fix): set frame_skip as an int

### DIFF
--- a/B-PROS(No-ops)/mainBpro.cpp
+++ b/B-PROS(No-ops)/mainBpro.cpp
@@ -56,7 +56,7 @@ int main(int argc, char** argv){
 
 	ale.setFloat("repeat_action_probability", 0.00);
 	ale.setInt("random_seed", 2*param.getSeed());
-	ale.setFloat("frame_skip", param.getNumStepsPerAction());
+	ale.setInt("frame_skip", param.getNumStepsPerAction());
 	ale.setInt("max_num_frames_per_episode", param.getEpisodeLength());
     ale.setBool("color_averaging", true);
 

--- a/B-PROS/mainBpro.cpp
+++ b/B-PROS/mainBpro.cpp
@@ -55,7 +55,7 @@ int main(int argc, char** argv){
 	ale.setBool("color_averaging", true);
 	ale.setFloat("repeat_action_probability", 0.00);
 	ale.setInt("random_seed", param.getSeed());
-	ale.setFloat("frame_skip", param.getNumStepsPerAction());
+	ale.setInt("frame_skip", param.getNumStepsPerAction());
 	ale.setInt("max_num_frames_per_episode", param.getEpisodeLength());
 
 	ale.loadROM(param.getRomPath().c_str());

--- a/B-PROST/mainTimeoffsets.cpp
+++ b/B-PROST/mainTimeoffsets.cpp
@@ -56,7 +56,7 @@ int main(int argc, char** argv){
 
 	ale.setFloat("repeat_action_probability", 0.00);
 	ale.setInt("random_seed", 2*param.getSeed());
-	ale.setFloat("frame_skip", param.getNumStepsPerAction());
+	ale.setInt("frame_skip", param.getNumStepsPerAction());
 	ale.setInt("max_num_frames_per_episode", param.getEpisodeLength());
     ale.setBool("color_averaging", true);
 

--- a/Blob-PROST/mainBlobTime.cpp
+++ b/Blob-PROST/mainBlobTime.cpp
@@ -56,7 +56,7 @@ int main(int argc, char** argv){
 
 	ale.setFloat("repeat_action_probability", 0.00);
 	ale.setInt("random_seed", 2*param.getSeed());
-	ale.setFloat("frame_skip", param.getNumStepsPerAction());
+	ale.setInt("frame_skip", param.getNumStepsPerAction());
 	ale.setInt("max_num_frames_per_episode", param.getEpisodeLength());
     ale.setBool("color_averaging", true);
 


### PR DESCRIPTION
`frame_skip` is now an int in newer ALE versions. This fixes the code to use the new format.